### PR TITLE
Feat/#5

### DIFF
--- a/src/components/common/Header/index.tsx
+++ b/src/components/common/Header/index.tsx
@@ -1,0 +1,28 @@
+import { StyleHeader, StyleInner, Content } from './style';
+import { memo } from 'react';
+/**
+ * @description 상단 Fixed 헤더 컴포넌트입니다.
+ * 확장성을 위해서 Left, Right, Center 컴포넌트를 Props로 사용할 수 있습니다.
+ */
+
+interface BaseHeaderProps {
+  leftContent?: React.ReactElement;
+  rightContent?: React.ReactElement;
+  centerContent?: React.ReactElement;
+}
+
+const Header = ({ leftContent, rightContent, centerContent }: BaseHeaderProps) => {
+  return (
+    <>
+      <StyleHeader>
+        <StyleInner>
+          <Content align={'flex-start'}>{leftContent}</Content>
+          <Content align={'center'}>{centerContent}</Content>
+          <Content align={'flex-end'}>{rightContent}</Content>
+        </StyleInner>
+      </StyleHeader>
+    </>
+  );
+};
+
+export default memo(Header);

--- a/src/components/common/Header/style.ts
+++ b/src/components/common/Header/style.ts
@@ -1,0 +1,25 @@
+import styled from 'styled-components';
+
+type IContent = {
+  align: 'flex-start' | 'center' | 'flex-end';
+};
+
+const StyleHeader = styled.header`
+  padding: 16px;
+  background-color: transparent;
+`;
+
+const StyleInner = styled.div`
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;
+
+const Content = styled.div<IContent>`
+  display: flex;
+  flex: 1;
+  justify-content: ${({ align }) => align};
+`;
+
+export { StyleHeader, StyleInner, Content };

--- a/src/hooks/useInterval.tsx
+++ b/src/hooks/useInterval.tsx
@@ -1,0 +1,22 @@
+import { useEffect, useRef } from 'react';
+
+type IntervalCallback = () => void;
+
+export default function useInterval(callback: IntervalCallback, delay: number | null) {
+  const savedCallback = useRef<IntervalCallback>(); // @NOTE : Ref를 활용하여 콜백함수가 변경되어도 Interval이 끝나지않음.
+  // 함수 최적화를 위한 변수 (최초 한번만 실행)
+  useEffect(() => {
+    savedCallback.current = callback;
+  }, [callback]);
+
+  useEffect(() => {
+    const callback = () => {
+      // @NOTE : 콜백함수가 없을 경우, Interval을 중지한다.
+      savedCallback.current && savedCallback.current();
+    };
+    if (delay !== null) {
+      const id = setInterval(callback, delay);
+      return () => clearInterval(id);
+    }
+  }, [delay]);
+}

--- a/src/layouts/index.tsx
+++ b/src/layouts/index.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { Wrapper } from './style';
+interface ILayoutProperties {
+  children: React.ReactNode;
+}
+
+const Layout = ({ children }: ILayoutProperties) => {
+  return <Wrapper>{children}</Wrapper>;
+};
+
+export default Layout;

--- a/src/layouts/style.ts
+++ b/src/layouts/style.ts
@@ -1,0 +1,11 @@
+import styled from 'styled-components';
+
+const Wrapper = styled.div`
+  width: 600px;
+  min-height: 100%;
+  margin: 0 auto;
+  padding: 0 16px;
+  background-image: linear-gradient(62deg, #fbab7e 0%, #f7ce68 100%);
+`;
+
+export { Wrapper };

--- a/src/lib/minesweeper.ts
+++ b/src/lib/minesweeper.ts
@@ -1,0 +1,140 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { CELL_FLAG } from './constants';
+import { createArray } from './creater';
+
+// @NOTE : 게임 보드 생성 함수
+export const initialBoard = (width: number, height: number, mineCount: number) => {
+  const candidates: number[] = createArray(width * height, null).map((_, i) => i); // 중복 방지를 위해 index 배열을 추가해 splice로 중복 값을 제거하기 위한 임의 배열
+  const shuffle: number[] = []; // 지뢰 위치를 저장하는 1차원 숫자 배열
+  const resultBoard: number[][] = []; // 연산 완료 된 2차원 게임 보드
+
+  // @NOTE : candidates 길이 > 지뢰를 제외한 빈 셀 = 지뢰 개수만큼 추출
+  // 지뢰 위치의 중복을 막기위해 이와 같은 로직을 적용
+  while (candidates.length > width * height - mineCount) {
+    const randomArrayIndex = Math.floor(candidates.length * Math.random()); // 중복 제거 된 배열 길이 사이의 숫자를 랜덤으로 추출
+    const chosen = candidates.splice(randomArrayIndex, 1)[0]; // 추출한 숫자를 제외한 나머지 숫자들을 추출한다.
+    shuffle.push(chosen);
+  }
+
+  // @NOTE : 전체 보드 Cell 생성 함수
+  for (let i = 0; i < height; i++) {
+    const rowArray = createArray(width, CELL_FLAG.NOTHING);
+    resultBoard.push(rowArray);
+  }
+
+  // @NOTE : 지뢰 위치 설정
+  for (const mineCell of shuffle) {
+    // 랜덤으로 지정 된 지뢰의 index 값을 이용해 x, y 좌표를 구한다.
+    const x = mineCell % width;
+    const y = Math.floor(mineCell / width);
+    resultBoard[y][x] = CELL_FLAG.MINE;
+  }
+
+  return resultBoard;
+};
+
+// @NOTE : 오른쪽 버튼 클릭 시, Flag 설정 함수
+export const getNextCellCode = (cell: number) => {
+  // 열지 않은 쉘 => Flag => 열지 않은 쉘 ... 방식으로 설정
+  switch (cell) {
+    case CELL_FLAG.NOTHING:
+      return CELL_FLAG.FLAG;
+    case CELL_FLAG.MINE:
+      return CELL_FLAG.MINE_FLAG;
+    case CELL_FLAG.FLAG:
+      return CELL_FLAG.NOTHING;
+    case CELL_FLAG.MINE_FLAG:
+      return CELL_FLAG.MINE;
+    default:
+      return cell;
+  }
+};
+
+// @NOTE: Flag 취소/적용 여부를 파악하고 설정하는 함수
+export const getFlagCount = (cell: number) => {
+  switch (cell) {
+    case CELL_FLAG.NOTHING:
+    case CELL_FLAG.MINE:
+      return 1;
+    case CELL_FLAG.FLAG:
+    case CELL_FLAG.MINE_FLAG:
+      return -1;
+    default:
+      return 0;
+  }
+};
+
+// @NOTE :
+export const openCell = (board: number[][], row: number, col: number) => {
+  let openCellCount = 0;
+
+  // @NOTE : 주어진 좌표의 셀이 지뢰인지 확인하여 Cell에 명시 할 Mine 개수를 구하는 함수
+  const getMineCount = (row: number, col: number) => {
+    let containCells: any[] = [];
+    let mineCount = 0;
+
+    // 선택한 셀 상단 3개
+    containCells = board[col - 1]
+      ? containCells.concat(board[col - 1][row - 1], board[col - 1][row], board[col - 1][row + 1])
+      : containCells;
+
+    // 선택한 셀 양 옆 2개
+    containCells = containCells.concat(board[col][row - 1], board[col][row + 1]);
+
+    // 선택한 셀 하단 3개
+    containCells = board[col + 1]
+      ? containCells.concat(board[col + 1][row - 1], board[col + 1][row], board[col + 1][row + 1])
+      : containCells;
+
+    // Cell에 표시 될 주변 지뢰+플래그를 가진 지뢰 개수를 구하는 Filter
+    mineCount = containCells.filter((v) =>
+      [CELL_FLAG.MINE, CELL_FLAG.MINE_FLAG].includes(v),
+    ).length;
+
+    return mineCount;
+  };
+
+  // @NOTE: 재귀 DFS 탐색을 활용한 열어야 할 셀을 찾는 함수
+  const boardSearchExplorer = (row: number, col: number) => {
+    // 해당 셀이 NOTHING이 아니라면, 재귀 탐색을 종료한다. (지뢰, 플래그, 열린 셀)
+    if (board[col][row] !== CELL_FLAG.NOTHING) {
+      return;
+    }
+
+    board[col][row] = getMineCount(row, col);
+    openCellCount++;
+
+    let stack: any[] = [];
+
+    // 탐색 중인 셀 상단 3개
+    stack = board[col - 1]
+      ? stack.concat(
+          { row: row - 1, col: col - 1 },
+          { row, col: col - 1 },
+          { row: row + 1, col: col - 1 },
+        )
+      : stack;
+    // 탐색 중인 셀 양 옆 2개
+    stack = stack.concat({ row: row - 1, col }, { row: row + 1, col });
+    // 탐색 중인 셀 하단 3개
+    stack = board[col + 1]
+      ? stack.concat(
+          { row: row - 1, col: col + 1 },
+          { row, col: col + 1 },
+          { row: row + 1, col: col + 1 },
+        )
+      : stack;
+
+    // @NOTE: 주변 셀이 모두 열려있으면, DFS방식의 탐색
+    if (board[col][row] === CELL_FLAG.OPEN) {
+      stack.forEach((cell) => {
+        boardSearchExplorer(cell.row, cell.col);
+      });
+    }
+  };
+
+  boardSearchExplorer(row, col);
+
+  // 탐색 완료한 보드, 열린 셀의 개수 반환
+  return { board, openCellCount };
+};

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,10 +1,8 @@
 import { configureStore } from '@reduxjs/toolkit';
 import { combineReducers } from 'redux';
-import { control } from './control';
-// import { composeWithDevTools } from 'redux-devtools-extension';
+import { control } from './modules/control';
 
 const combinedReducer = combineReducers({
-  // reducers go here
   control: control.reducer,
 });
 

--- a/src/store/modules/control.tsx
+++ b/src/store/modules/control.tsx
@@ -1,0 +1,96 @@
+import { initialBoard, openCell, getNextCellCode, getFlagCount } from '~lib/minesweeper';
+import { CELL_FLAG, STATUS, BOARD_SIZE, BOARD_MINE_COUNT } from '~lib/constants';
+import { createSlice } from '@reduxjs/toolkit';
+
+export interface ControlState {
+  board: number[][];
+  width: number;
+  height: number;
+  status: string;
+  flagCount: number;
+  mineCount: number;
+  openCellCount: number;
+  isRunning: boolean;
+  timer: number;
+}
+
+const initialState: ControlState = {
+  board: initialBoard(BOARD_SIZE, BOARD_SIZE, BOARD_MINE_COUNT) as number[][],
+  width: BOARD_SIZE,
+  height: BOARD_SIZE,
+  status: STATUS.READY,
+  flagCount: 0,
+  mineCount: BOARD_MINE_COUNT,
+  openCellCount: 0,
+  isRunning: false,
+  timer: 0,
+};
+
+export const control = createSlice({
+  name: 'control',
+  initialState,
+  reducers: {
+    startGame: (state): void => {
+      state.board = initialBoard(state.width, state.height, state.mineCount);
+      state.width = BOARD_SIZE;
+      state.height = BOARD_SIZE;
+      state.status = STATUS.READY;
+      state.flagCount = 0;
+      state.mineCount = BOARD_MINE_COUNT;
+      state.openCellCount = 0;
+      state.isRunning = false;
+      state.timer = 0;
+    },
+    updateTimer: (state): void => {
+      // @NOTE: 업데이트 타이머 호출 시, 타이머 시간을 1초 증가시킨다.
+      state.timer += 1;
+    },
+    openCell: (state, action): void => {
+      const { row, col } = action.payload;
+      const cell = state.board[col][row];
+      state.status = STATUS.RUN;
+
+      // @NOTE: Timer가 시작되지 않았을 때, 시작시킴.
+      if (!state.isRunning) {
+        state.isRunning = true;
+      }
+
+      // @NOTE: 선택 한 셸 상태 검증 로직
+      switch (cell) {
+        // @NOTE: 선택한 쉘이 지뢰 일 경우,
+        case CELL_FLAG.MINE: {
+          state.status = STATUS.LOSE; // 게임 오버 설정
+          state.isRunning = false; // 타이머 중지
+          break;
+        }
+        // @NOTE: 선택한 쉘이 지뢰가 아닌 경우,
+        case CELL_FLAG.NOTHING: {
+          const openedResultBoard = openCell(state.board, row, col);
+          state.board = openedResultBoard.board;
+          state.openCellCount += openedResultBoard.openCellCount;
+
+          // @NOTE: (총 보드 사이즈 - 총 지뢰 수 = 열린 셀 수) -> 게임 승리 조건
+          const isWin = state.width * state.height - state.mineCount === state.openCellCount;
+
+          // @NOTE: 만약 이겼을 시 상태를 WIN으로 변경하고, 시간을 종료한다.
+          if (isWin) {
+            state.status = STATUS.WIN;
+            state.isRunning = false;
+          }
+          break;
+        }
+        default:
+          break;
+      }
+    },
+    changeFlagState: (state, action): void => {
+      const { row, col } = action.payload;
+      const cell = state.board[col][row];
+
+      if (cell !== CELL_FLAG.OPEN) {
+        state.board[col][row] = getNextCellCode(cell);
+        state.flagCount += getFlagCount(cell);
+      }
+    },
+  },
+});

--- a/src/styles/globalStyle.ts
+++ b/src/styles/globalStyle.ts
@@ -11,6 +11,11 @@ const GlobalStyle = createGlobalStyle`
     * {
         box-sizing: border-box;
     }
+
+    a, a:hover, a:active, a:visited {
+        text-decoration: none;
+        color: inherit;
+    }
 `;
 
 export default GlobalStyle;


### PR DESCRIPTION
> closed #5, closed #9

## ❗ 구현 내용
- Header 컴포넌트 정의
- Layouts 템플릿 컴포넌트 정의
- RTK 방식의 게임 컨트롤러 전역 상태 정의 
  - useInterval
  - 보드 생성 함수 정의 `intialBoard`  40e88c19e13e593b0b209fafacb6487c81d5f07b
  - Flag 설정/카운팅 함수 정의 `getNextCellCode`, `getFlagCount` 40e88c19e13e593b0b209fafacb6487c81d5f07b
  - DFS 깊이 탐색을 활용한 Board 탐색 기능 적용 `openCell` 40e88c19e13e593b0b209fafacb6487c81d5f07b



## 🎞 스크린샷

![image](https://user-images.githubusercontent.com/60251579/166672423-cd6c1d46-6250-414d-a099-8df27a15dce7.png)
